### PR TITLE
Update code to support CF 5.0

### DIFF
--- a/library/manageiq_config.py
+++ b/library/manageiq_config.py
@@ -105,7 +105,7 @@ def get_manageiq_config_value(module, name):
     returncode, out, err = module.run_command([
         "rails",
         "r",
-        "puts MiqServer.my_server.get_config(:%s).config.to_json" % (name)
+        "puts Vmdb::Settings.for_resource(MiqServer.my_server)[:%s].to_json" % (name)
     ], cwd=module.params['vmdb_path'])
     if returncode != 0:
         raise Exception("Error getting existing value for ':%s' config: %s" % (name, err))


### PR DESCRIPTION
+ change how existing setting are retrieved from server
  + miq_server.get_config was removed

Verified this on 4.7 and 5.0 appliances.
```
# python
>>> import os
>>> name = 'workers'
>>> command = "puts Vmdb::Settings.for_resource(MiqServer.my_server)[:%s].to_json" % (name)
>>> os.system("bash -c 'pushd /var/www/miq/vmdb ; ./bin/rails runner \"%s\"'" %(command))
/var/www/miq/vmdb /var/www/miq/vmdb
{"worker_base":{"event_catcher":{"event_catcher_amazon":{"poll":"15.seconds"},"event_catcher_azure":{"poll":"15.seconds"},"event_catcher_google":{"poll":"15.seconds"},"event
_catcher_kubernetes" ....
```
